### PR TITLE
fix version requirement to use correct syntax

### DIFF
--- a/lib/Config/Reload.pm
+++ b/lib/Config/Reload.pm
@@ -4,7 +4,7 @@ package Config::Reload;
 use v5.10;
 use strict;
 
-use Config::ZOMG '1.000000';
+use Config::ZOMG 1.000000;
 
 use Moo;
 use Sub::Quote 'quote_sub';


### PR DESCRIPTION
Version numbers on a use line need to be unquoted to be handled properly. When they are quoted, they are passed in import instead. Part versions of perl ignored these arguments, but future versions are intending to throw errors for arguments given to an undefined import method.